### PR TITLE
Fix for "Javascript error when DataTable is empty"

### DIFF
--- a/DataTables.php
+++ b/DataTables.php
@@ -107,4 +107,14 @@ class DataTables extends \yii\grid\GridView
     {
         return $this->clientOptions;
     }
+    
+    public function renderTableBody()
+    {
+        $models = array_values($this->dataProvider->getModels());
+        if (count($models) === 0) {
+            return "<tbody>\n</tbody>";
+        } else {
+            return parent::renderTableBody();
+        }
+    }
 }


### PR DESCRIPTION
Override renderTableBody to draw a blank tbody without empty message to prevent conflict with datatables rendering.